### PR TITLE
Update BearingLoads.cpp (Ready to merge)

### DIFF
--- a/EngTools/BearingCalculator.cpp
+++ b/EngTools/BearingCalculator.cpp
@@ -951,7 +951,7 @@ bool BearingCalculator::StaticAxialSecondaryShearStrainCheck(const Bearing& brg,
 
 bool BearingCalculator::PrimaryShearStrainComboSumCheck(const Bearing& brg, const BearingLoads& brg_loads) const
 {
-	if (GetPrimaryShearStrainComboSum(brg, brg_loads) <= 5.0)
+	if (abs(GetPrimaryShearStrainComboSum(brg, brg_loads)) <= 5.0)
 	{
 		return true;
 	}
@@ -963,7 +963,7 @@ bool BearingCalculator::PrimaryShearStrainComboSumCheck(const Bearing& brg, cons
 
 bool BearingCalculator::SecondaryShearStrainComboSumCheck(const Bearing& brg, const BearingLoads& brg_loads) const
 {
-	if (GetSecondaryShearStrainComboSum(brg, brg_loads) <= 5.0)
+	if (abs(GetSecondaryShearStrainComboSum(brg, brg_loads)) <= 5.0)
 	{
 		return true;
 	}

--- a/EngTools/BearingLoads.cpp
+++ b/EngTools/BearingLoads.cpp
@@ -50,11 +50,11 @@ void BearingLoads::SetRotationY(Float64 ry)
 }
 void BearingLoads::SetStaticRotation(Float64 rst)
 {
-    m_static_rotation = abs(rst);
+    m_static_rotation = rst;
 }
 void BearingLoads::SetCyclicRotation(Float64 rcy)
 {
-    m_cyclic_rotation = abs(rcy);
+    m_cyclic_rotation = rcy;
 }
 void BearingLoads::SetShearDeformation(Float64 shear_def)
 {


### PR DESCRIPTION
[sign convention.docx](https://github.com/user-attachments/files/17403449/sign.convention.docx)

I created a plan for making sign conventions consistent across the BrgCalc application and the new bearing design parameters report. The first step is to stop making the rotations absolute values. See attached. That way it aligns exactly with the Excel calculator by R. Dornsiphe.