### PR TITLE
Adds new rptRcEquation object (Ready for testing)

### DIFF
--- a/Include/Reporter/HtmlRcVisitor.h
+++ b/Include/Reporter/HtmlRcVisitor.h
@@ -85,6 +85,9 @@ public:
    /// Visit an image
    void VisitRcImage(rptRcImage*);
 
+   /// Visit an equation
+   void VisitRcEquation(rptRcEquation*);
+
    /// Visit a symbol
    void VisitRcSymbol(rptRcSymbol*);
 

--- a/Include/Reporter/RcEquation.h
+++ b/Include/Reporter/RcEquation.h
@@ -1,0 +1,87 @@
+///////////////////////////////////////////////////////////////////////
+// Reporter - Report Creation and Representation Library
+// Copyright © 1999-2024  Washington State Department of Transportation
+//                        Bridge and Structures Office
+//
+// This library is a part of the Washington Bridge Foundation Libraries
+// and was developed as part of the Alternate Route Project
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the Alternate Route Library Open Source License as published by 
+// the Washington State Department of Transportation, Bridge and Structures Office.
+//
+// This program is distributed in the hope that it will be useful, but is distributed 
+// AS IS, WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY 
+// or FITNESS FOR A PARTICULAR PURPOSE. See the Alternate Route Library Open Source 
+// License for more details.
+//
+// You should have received a copy of the Alternate Route Library Open Source License 
+// along with this program; if not, write to the Washington State Department of 
+// Transportation, Bridge and Structures Office, P.O. Box  47340, 
+// Olympia, WA 98503, USA or e-mail Bridge_Support@wsdot.wa.gov
+///////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include <Reporter\ReporterExp.h>
+#include <Reporter\ReportContent.h>
+#include <string>
+
+/// Report content for an image.
+///
+/// This type of report content allows a static image file or LaTaX to be placed into a report.
+class REPORTERCLASS rptRcEquation : public rptReportContent
+{
+public:
+
+   /// Math display type
+   enum Display
+   {
+       InLine,
+       Block,
+   };
+
+   /// Creates equation content with an unspecified image file and LaTex code
+   rptRcEquation();
+
+   rptRcEquation(
+      const std::_tstring& fileName, ///< Path to image file
+      const std::_tstring& laTeX, ///< LaTex code
+      Display dsp=InLine ///< math display type
+   );
+
+   rptRcEquation(const rptRcEquation& rOther);
+
+   virtual ~rptRcEquation();
+
+   rptRcEquation& operator=(const rptRcEquation& rOther);
+
+   /// Accepts a visitor and calls VisitRcEquation(this)
+   virtual void Accept( rptRcVisitor& rVisitor ) override;
+
+   /// Creates a clone
+   virtual rptReportContent* CreateClone() const override;
+
+   /// Returns the name of the image file
+   const std::_tstring& GetFileName() const;
+
+   /// Returns the code for LaTex
+   const std::_tstring& GetLaTeX() const;
+
+   /// Sets the name of the image file
+   void SetFileName(const std::_tstring& fileName);
+
+   /// Sets the code LaTeX
+   void SetLaTeX(const std::_tstring& laTex);
+
+   /// Sets the math display
+   void SetMathDisplay(Display dsp);
+
+   /// Returns the math display
+   Display GetMathDisplay() const;
+
+private:
+   std::_tstring m_FileName;
+   std::_tstring m_LaTeX;
+   Display m_mathDisplay;
+};

--- a/Include/Reporter/RcVisitor.h
+++ b/Include/Reporter/RcVisitor.h
@@ -40,6 +40,7 @@ class REPORTERCLASS rptParagraph;
 class REPORTERCLASS rptRcDateTime;
 class REPORTERCLASS rptRcHyperTarget;
 class REPORTERCLASS rptRcImage;
+class REPORTERCLASS rptRcEquation;
 class REPORTERCLASS rptRcSymbol;
 class REPORTERCLASS rptRcScalar;
 class REPORTERCLASS rptRcPercentage;
@@ -70,6 +71,7 @@ public:
    virtual void VisitRcDateTime(rptRcDateTime*) = 0;
    virtual void VisitRcHyperTarget(rptRcHyperTarget*) = 0;
    virtual void VisitRcImage(rptRcImage*) = 0;
+   virtual void VisitRcEquation(rptRcEquation*) = 0;
    virtual void VisitRcSymbol(rptRcSymbol*) = 0;
    virtual void VisitRcScalar(rptRcScalar*) = 0;
    virtual void VisitRcPercentage(rptRcPercentage*) = 0;

--- a/Include/Reporter/Reporter.h
+++ b/Include/Reporter/Reporter.h
@@ -60,6 +60,7 @@
 #include <Reporter\RcUnsigned.h>
 #include <Reporter\RcComposite.h>
 #include <Reporter\RcImage.h>
+#include <Reporter\RcEquation.h>
 #include <Reporter\RcDateTime.h>
 #include <Reporter\PageLayout.h>
 #include <Reporter\HtmlReportVisitor.h>

--- a/Reporter/HtmlRcVisitor.cpp
+++ b/Reporter/HtmlRcVisitor.cpp
@@ -38,6 +38,7 @@
 #include <Reporter\RcDateTime.h>
 #include <Reporter\RcHyperTarget.h>
 #include <Reporter\RcImage.h>
+#include <Reporter\RcEquation.h>
 #include <Reporter\RcSymbol.h>
 #include <Reporter\RcScalar.h>
 #include <Reporter\RcPercentage.h>
@@ -582,6 +583,26 @@ void rptHtmlRcVisitor::VisitRcImage(rptRcImage* pImage)
 
       *m_pOstream << _T("/>") << std::endl;
    }
+}
+
+void rptHtmlRcVisitor::VisitRcEquation(rptRcEquation* pEqn)
+{
+    if (m_Helper.GetBrowserType() == rptHtmlHelper::BrowserType::Edge)
+    {
+        if (pEqn->GetMathDisplay() == rptRcEquation::InLine)
+        {
+            *m_pOstream << _T("\\({\\displaystyle ") << pEqn->GetLaTeX() << _T("}\\)") << std::endl;
+        }
+        else
+        {
+            *m_pOstream << _T("$$\\displaystyle ") << pEqn->GetLaTeX() << _T("$$") << std::endl;
+        }
+    }
+    else
+    {
+        rptRcImage pImage(pEqn->GetFileName());
+        VisitRcImage(&pImage);
+    }
 }
 
 //------------------------------------------------------------------------

--- a/Reporter/HtmlReportVisitor.cpp
+++ b/Reporter/HtmlReportVisitor.cpp
@@ -98,6 +98,15 @@ void rptHtmlReportVisitor::VisitReport(rptReport* pReport)
 //   }
 
 
+   
+   if (m_Helper.GetBrowserType() == rptHtmlHelper::BrowserType::Edge)
+   {
+       *m_pOstream << _T("<script type = \"text/javascript\"") << std::endl;
+       *m_pOstream << _T("    src = \"http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML\">") << std::endl;
+       *m_pOstream << _T("</script>") << std::endl;
+   }
+
+
    *m_pOstream << _T("</head>") << std::endl<<std::endl;
 
    *m_pOstream << _T("<BODY onDragStart=\"onde()\" >") << std::endl;
@@ -145,6 +154,7 @@ void rptHtmlReportVisitor::VisitReport(rptReport* pReport)
       //   *m_pOstream << _T("   alert(\"Table copied to clipboard. You can now past into Word or Excel\");") << std::endl;
       *m_pOstream << _T("}") << std::endl;
       *m_pOstream << _T("</script>") << std::endl;
+
    }
 
    *m_pOstream << _T("</html>") <<std::endl;

--- a/Reporter/RcEquation.cpp
+++ b/Reporter/RcEquation.cpp
@@ -1,0 +1,117 @@
+///////////////////////////////////////////////////////////////////////
+// Reporter - Report Creation and Representation Library
+// Copyright © 1999-2024  Washington State Department of Transportation
+//                        Bridge and Structures Office
+//
+// This library is a part of the Washington Bridge Foundation Libraries
+// and was developed as part of the Alternate Route Project
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the Alternate Route Library Open Source License as published by 
+// the Washington State Department of Transportation, Bridge and Structures Office.
+//
+// This program is distributed in the hope that it will be useful, but is distributed 
+// AS IS, WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY 
+// or FITNESS FOR A PARTICULAR PURPOSE. See the Alternate Route Library Open Source 
+// License for more details.
+//
+// You should have received a copy of the Alternate Route Library Open Source License 
+// along with this program; if not, write to the Washington State Department of 
+// Transportation, Bridge and Structures Office, P.O. Box  47340, 
+// Olympia, WA 98503, USA or e-mail Bridge_Support@wsdot.wa.gov
+///////////////////////////////////////////////////////////////////////
+
+#include <Reporter\ReporterLib.h>
+
+#include <Reporter\RcEquation.h>
+#include <Reporter\RcVisitor.h>
+#include <sstream>
+
+rptRcEquation::rptRcEquation() :
+rptReportContent(),
+m_FileName( _T("Unspecified") ),
+m_mathDisplay(InLine)
+{
+}
+
+rptRcEquation::rptRcEquation(const std::_tstring& fileName, const std::_tstring& laTeX, rptRcEquation::Display dsp) :
+rptReportContent(),
+m_FileName( fileName ),
+m_LaTeX(laTeX),
+m_mathDisplay(dsp)
+{
+}
+
+rptRcEquation::rptRcEquation(const rptRcEquation& rOther) :
+rptReportContent(rOther)
+{
+   m_FileName = rOther.m_FileName;
+   m_LaTeX = rOther.m_LaTeX;
+   m_mathDisplay = rOther.m_mathDisplay;
+}
+
+rptRcEquation::~rptRcEquation()
+{
+}
+
+rptRcEquation& rptRcEquation::operator= (const rptRcEquation& rOther)
+{
+   if( this != &rOther )
+   {
+      m_FileName = rOther.m_FileName;
+      m_LaTeX = rOther.m_LaTeX;
+      m_mathDisplay = rOther.m_mathDisplay;
+   }
+
+   return *this;
+}
+
+void rptRcEquation::Accept( rptRcVisitor& rVisitor )
+{
+#if defined _DEBUG
+   // test to make sure the file exists
+   WIN32_FIND_DATA findData;
+   HANDLE handle = ::FindFirstFile(m_FileName.c_str(),&findData);
+   CHECK(handle != INVALID_HANDLE_VALUE);
+   if ( handle != INVALID_HANDLE_VALUE )
+      ::FindClose(handle);
+#endif
+   rVisitor.VisitRcEquation( this );
+}
+
+rptReportContent* rptRcEquation::CreateClone() const
+{
+   return new rptRcEquation( *this );
+}
+
+//======================== ACCESS     =======================================
+
+const std::_tstring& rptRcEquation::GetFileName() const
+{
+   return m_FileName;
+}
+
+void rptRcEquation::SetFileName(const std::_tstring& fileName)
+{
+   m_FileName = fileName;
+}
+
+const std::_tstring& rptRcEquation::GetLaTeX() const
+{
+    return m_LaTeX;
+}
+
+void rptRcEquation::SetLaTeX(const std::_tstring& LaTeX)
+{
+    m_LaTeX = LaTeX;
+}
+
+void rptRcEquation::SetMathDisplay(rptRcEquation::Display dsp)
+{
+    m_mathDisplay = dsp;
+}
+
+rptRcEquation::Display rptRcEquation::GetMathDisplay() const
+{
+    return m_mathDisplay;
+}

--- a/Reporter/Reporter.vcxproj
+++ b/Reporter/Reporter.vcxproj
@@ -211,6 +211,7 @@
     <ClCompile Include="RcColor.cpp" />
     <ClCompile Include="RcComposite.cpp" />
     <ClCompile Include="RcDateTime.cpp" />
+    <ClCompile Include="RcEquation.cpp" />
     <ClCompile Include="RcFlowModifier.cpp" />
     <ClCompile Include="RcFontModifier.cpp" />
     <ClCompile Include="RcHyperTarget.cpp" />
@@ -267,6 +268,7 @@
     <ClInclude Include="..\Include\Reporter\RcColor.h" />
     <ClInclude Include="..\Include\Reporter\RcComposite.h" />
     <ClInclude Include="..\Include\Reporter\RcDateTime.h" />
+    <ClInclude Include="..\Include\Reporter\RcEquation.h" />
     <ClInclude Include="..\Include\Reporter\RcFlowModifier.h" />
     <ClInclude Include="..\Include\Reporter\RcFontModifier.h" />
     <ClInclude Include="..\Include\Reporter\RcHyperTarget.h" />

--- a/Reporter/Reporter.vcxproj.filters
+++ b/Reporter/Reporter.vcxproj.filters
@@ -166,6 +166,9 @@
     <ClCompile Include="Heading.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="RcEquation.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\Include\Reporter\AutoLib.h">
@@ -343,6 +346,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\Include\Reporter\Heading.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\Include\Reporter\RcEquation.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>


### PR DESCRIPTION
This object is instantiated with equation image file, and raw LaTeX as parameters. Can be used in place of rptRcImage for handling equations. When Edge browse is used, the LaTeX is displayed, otherwise the image is used.