### PR TITLE
hides unintended vertical lines in Spec Check Report

### DIFF
--- a/Reporter/HtmlRcVisitor.cpp
+++ b/Reporter/HtmlRcVisitor.cpp
@@ -190,8 +190,18 @@ void rptHtmlRcVisitor::VisitRcTable(rptRcTable* pTable)
    }
 
    // table setup
-   *m_pOstream << _T("<TABLE BORDER=")<< out_pixels<<_T(" RULES=ALL CELLSPACING=")<<in_pixels
-               << _T(" CELLPADDING=")<<cell_pad_pixels;
+   if (m_Helper.GetBrowserType() == rptHtmlHelper::BrowserType::Edge && pTable->GetOutsideBorderStyle() == rptRiStyle::NOBORDER)
+   {
+        *m_pOstream << _T("<TABLE CLASS = \"no-border\"") << _T(" RULES=ALL CELLSPACING=") << in_pixels
+            << _T(" CELLPADDING=") << cell_pad_pixels;
+   }
+   else
+   {
+       *m_pOstream << _T("<TABLE BORDER=") << out_pixels << _T(" RULES=ALL CELLSPACING=") << in_pixels
+           << _T(" CELLPADDING=") << cell_pad_pixels;
+   }
+   
+
 
    if ( 0 < table_width_px )
       *m_pOstream <<_T(" WIDTH=\"")<<table_width_px;

--- a/Reporter/HtmlReportVisitor.cpp
+++ b/Reporter/HtmlReportVisitor.cpp
@@ -69,7 +69,12 @@ void rptHtmlReportVisitor::VisitReport(rptReport* pReport)
     }
 
    // Use html helper to Write out style block
-   m_Helper.VisitFontLibrary(*m_pOstream);
+   m_Helper.VisitFontLibrary(*m_pOstream); 
+
+#pragma Reminder("UPDATE: implement on-border in VisitFontLibrary")
+   *m_pOstream << _T("<style>") << std::endl;
+   *m_pOstream << _T(".no-border td {border:none; outline:none; border-collapse:collapse;}") << std::endl;
+   *m_pOstream << _T("</style>") << std::endl;
 
    // Use MEDIA attribute of STYLE tag to handle differences between
    // printing and viewing.


### PR DESCRIPTION
when border style is NOBORDER it adds the attribute border = 0 in the table element. This does not work in the Edge browser so I added the 'no-border' class to the CSS style so it can be used in the table element as needed.