### PR TITLE
corrects reported bearing height dimension

### DIFF
--- a/EngTools/BearingCalculator.cpp
+++ b/EngTools/BearingCalculator.cpp
@@ -54,6 +54,15 @@ BearingCalculator::AnalysisMethod BearingCalculator::GetAnalysisMethod() const
 	return m_method;
 }
 
+Float64 BearingCalculator::ComputeBearingHeight(const Bearing& brg) const
+{
+	int n = brg.GetNumIntLayers();
+	Float64 hrt = brg.GetTotalElastomerThickness();
+	Float64 hst = brg.GetSteelShimThickness();
+	Float64 totalHeight = hrt + (n + 1) * hst;
+	return totalHeight;
+}
+
 Float64 BearingCalculator::GetMaximumAllowableStress() const
 {
 	return m_maximum_allowable_stress;

--- a/EngTools/BearingReporter.cpp
+++ b/EngTools/BearingReporter.cpp
@@ -81,6 +81,7 @@ void ReportBearingProperties(const WBFL::Units::IndirectMeasure* pDispUnits,
 	Float64 x_rotation = brg_loads.GetRotationX();
 	Float64 y_rotation = brg_loads.GetRotationY();
 	Float64 total_elastomer_thickness = brg.GetTotalElastomerThickness();
+	Float64 total_bearing_height = brg_calc.ComputeBearingHeight(brg);
 	Float64 tlayer = brg.GetIntermediateLayerThickness();
 	Float64 tshim = brg.GetSteelShimThickness();
 	Float64 weight = brg.GetBearingWeight();
@@ -111,7 +112,7 @@ void ReportBearingProperties(const WBFL::Units::IndirectMeasure* pDispUnits,
 	*pPara << color(Blue);
 	*pPara << _T("Summary:") << rptNewLine;
 	*pPara << _T("Dimensions: ") << length.SetValue(w) << _T(" ") << symbol(TIMES) << length.SetValue(l);
-	*pPara << _T(" ") << symbol(TIMES) << length.SetValue(total_elastomer_thickness);
+	*pPara << _T(" ") << symbol(TIMES) << length.SetValue(total_bearing_height);
 	*pPara << color(Blue) << rptNewLine;
 	*pPara << _T("Approx. Weight = ");
 	if (pDispUnits->Name == _T("English"))
@@ -601,7 +602,7 @@ void ReportBearingSpecificationCheckA(const WBFL::Units::IndirectMeasure* pDispU
 	}
 	else
 	{
-		*pPara << color(Red) << symbol(RIGHT_SINGLE_ARROW) << s << _T(" > ") << s_max << _T(" ") << RPT_FAIL << color(Red) << _T(" (METHOD A CANNOT BE USED per SECTION 14.7.6.1) ") << color(Red) << rptNewLine;
+		*pPara << color(Red) << symbol(RIGHT_SINGLE_ARROW) << s << _T(" > ") << s_max << _T(" ") << RPT_FAIL << color(Red) << _T(" (METHOD A cannot be used per SECTION 14.7.6.1) ") << color(Red) << rptNewLine;
 	}
 	*pPara << rptNewLine;
 

--- a/Include/EngTools/BearingCalculator.h
+++ b/Include/EngTools/BearingCalculator.h
@@ -76,6 +76,8 @@ namespace WBFL
             /// @param k
             void SetElastomerBulkModulus(Float64 k);
 
+            /// @return computes total bearing height
+            Float64 ComputeBearingHeight(const Bearing& brg) const;
 
             /// @return analysis method
             AnalysisMethod GetAnalysisMethod() const;


### PR DESCRIPTION
previously reported total elastomer thickness as the "height" dimension. The bearing height should include total elastomer thickness plus the shims.