### PR TITLE
adds bearing design criteria

### DIFF
--- a/EngTools/BearingCalculator.cpp
+++ b/EngTools/BearingCalculator.cpp
@@ -40,6 +40,10 @@ void BearingCalculator::SetAnalysisMethod(BearingCalculator::AnalysisMethod meth
 {
 	m_method = method;
 }
+void BearingCalculator::SetDesignCriteria(const BearingCalculator::Criteria& criteria)
+{
+	m_criteria = criteria;
+}
 void BearingCalculator::SetMaximumAllowableStress(Float64 sigma_max)
 {
 	m_maximum_allowable_stress = sigma_max;
@@ -47,6 +51,15 @@ void BearingCalculator::SetMaximumAllowableStress(Float64 sigma_max)
 void BearingCalculator::SetElastomerBulkModulus(Float64 k)
 {
 	m_elastomer_bulk_modulus = k;
+}
+
+Float64 BearingCalculator::ComputeBearingHeight(const Bearing& brg) const
+{
+	int n = brg.GetNumIntLayers();
+	Float64 hrt = brg.GetTotalElastomerThickness();
+	Float64 hst = brg.GetSteelShimThickness();
+	Float64 totalHeight = hrt + (n + 1) * hst;
+	return totalHeight;
 }
 
 BearingCalculator::AnalysisMethod BearingCalculator::GetAnalysisMethod() const
@@ -1098,6 +1111,115 @@ bool BearingCalculator::HorizontalForceCheck(const Bearing& brg, const BearingLo
 {
 	if (GetHorizontalForce(brg,brg_loads) <= brg_loads.GetDeadLoad()/5.0)
 
+	{
+		return true;
+	}
+	else
+	{
+		return false;
+	}
+}
+
+
+bool BearingCalculator::MinimumAllowableShearModulusCheck(const Bearing& brg, const Criteria& criteria) const
+{
+	if (brg.GetShearModulusMinimum() >= criteria.Gmin && brg.GetShearModulusMaximum() >= criteria.Gmin)
+	{
+		return true;
+	}
+	else
+	{
+		return false;
+	}
+}
+
+bool BearingCalculator::MaximumAllowableShearModulusCheck(const Bearing& brg, const Criteria& criteria) const
+{
+	if (brg.GetShearModulusMinimum() <= criteria.Gmax && brg.GetShearModulusMaximum() <= criteria.Gmax)
+	{
+		return true;
+	}
+	else
+	{
+		return false;
+	}
+}
+
+bool BearingCalculator::RequiredIntermediateElastomerThicknessCheck(const Bearing& brg, const Criteria& criteria) const
+{
+	if (brg.GetIntermediateLayerThickness() == criteria.hri)
+	{
+		return true;
+	}
+	else
+	{
+		return false;
+	}
+}
+
+bool BearingCalculator::MinimumTotalBearingHeightCheck(const Bearing& brg, const Criteria& criteria) const
+{
+	if (ComputeBearingHeight(brg) >= criteria.minHeight)
+	{
+		return true;
+	}
+	else
+	{
+		return false;
+	}
+}
+
+bool BearingCalculator::MinimumBearingEdgeToBottomFlangeEdgeDistCheck(const Bearing& brg, const Criteria& criteria, Float64 gdrFlgDist) const
+{
+	if (gdrFlgDist - brg.GetWidth() / 2.0 >= criteria.minDistBrg2gBf)
+	{
+		return true;
+	}
+	else
+	{
+		return false;
+	}
+}
+
+bool BearingCalculator::MaximumBearingEdgeToBottomFlangeEdgeDistCheck(const Bearing& brg, const Criteria& criteria, Float64 gdrFlgDist) const
+{
+	if (gdrFlgDist - brg.GetWidth() / 2.0 <= criteria.maxDistBrg2gBf)
+	{
+		return true;
+	}
+	else
+	{
+		return false;
+	}
+}
+
+bool BearingCalculator::RequiredBearingEdgeToBottomFlangeEdgeDistCheck(const Bearing& brg, const Criteria& criteria, Float64 gdrFlgDist) const
+{
+	if (gdrFlgDist - brg.GetWidth() / 2.0 <= criteria.distBrg2gBf)
+	{
+		return true;
+	}
+	else
+	{
+		return false;
+	}
+}
+
+bool BearingCalculator::MaximumLiveLoadDeflectionCheck(const Bearing& brg, const BearingLoads& brg_loads, const Criteria& criteria) const
+{
+	if (GetInstantaneousLiveLoadDeflectionMethodB(brg, brg_loads) <= criteria.maxLLdef)
+	{
+		return true;
+	}
+	else
+	{
+		return false;
+	}
+}
+
+bool BearingCalculator::MaximumTotalLoadCheck(const BearingLoads& brg_loads, const Criteria& criteria) const
+{
+	if (brg_loads.GetTotalLoad() <= criteria.maxTL)
 	{
 		return true;
 	}

--- a/EngTools/BearingCalculator.cpp
+++ b/EngTools/BearingCalculator.cpp
@@ -67,15 +67,6 @@ BearingCalculator::AnalysisMethod BearingCalculator::GetAnalysisMethod() const
 	return m_method;
 }
 
-Float64 BearingCalculator::ComputeBearingHeight(const Bearing& brg) const
-{
-	int n = brg.GetNumIntLayers();
-	Float64 hrt = brg.GetTotalElastomerThickness();
-	Float64 hst = brg.GetSteelShimThickness();
-	Float64 totalHeight = hrt + (n + 1) * hst;
-	return totalHeight;
-}
-
 Float64 BearingCalculator::GetMaximumAllowableStress() const
 {
 	return m_maximum_allowable_stress;
@@ -1120,10 +1111,9 @@ bool BearingCalculator::HorizontalForceCheck(const Bearing& brg, const BearingLo
 	}
 }
 
-
 bool BearingCalculator::MinimumAllowableShearModulusCheck(const Bearing& brg, const Criteria& criteria) const
 {
-	if (brg.GetShearModulusMinimum() >= criteria.Gmin && brg.GetShearModulusMaximum() >= criteria.Gmin)
+	if (brg.GetShearModulusMinimum() >= criteria.Gmin)
 	{
 		return true;
 	}
@@ -1135,7 +1125,7 @@ bool BearingCalculator::MinimumAllowableShearModulusCheck(const Bearing& brg, co
 
 bool BearingCalculator::MaximumAllowableShearModulusCheck(const Bearing& brg, const Criteria& criteria) const
 {
-	if (brg.GetShearModulusMinimum() <= criteria.Gmax && brg.GetShearModulusMaximum() <= criteria.Gmax)
+	if (brg.GetShearModulusMaximum() <= criteria.Gmax)
 	{
 		return true;
 	}
@@ -1171,7 +1161,7 @@ bool BearingCalculator::MinimumTotalBearingHeightCheck(const Bearing& brg, const
 
 bool BearingCalculator::MinimumBearingEdgeToBottomFlangeEdgeDistCheck(const Bearing& brg, const Criteria& criteria, Float64 gdrFlgDist) const
 {
-	if (gdrFlgDist - brg.GetWidth() / 2.0 >= criteria.minDistBrg2gBf)
+	if (gdrFlgDist >= criteria.minDistBrg2gBf)
 	{
 		return true;
 	}
@@ -1183,7 +1173,7 @@ bool BearingCalculator::MinimumBearingEdgeToBottomFlangeEdgeDistCheck(const Bear
 
 bool BearingCalculator::MaximumBearingEdgeToBottomFlangeEdgeDistCheck(const Bearing& brg, const Criteria& criteria, Float64 gdrFlgDist) const
 {
-	if (gdrFlgDist - brg.GetWidth() / 2.0 <= criteria.maxDistBrg2gBf)
+	if (gdrFlgDist <= criteria.maxDistBrg2gBf)
 	{
 		return true;
 	}
@@ -1195,7 +1185,7 @@ bool BearingCalculator::MaximumBearingEdgeToBottomFlangeEdgeDistCheck(const Bear
 
 bool BearingCalculator::RequiredBearingEdgeToBottomFlangeEdgeDistCheck(const Bearing& brg, const Criteria& criteria, Float64 gdrFlgDist) const
 {
-	if (gdrFlgDist - brg.GetWidth() / 2.0 <= criteria.distBrg2gBf)
+	if (gdrFlgDist == criteria.distBrg2gBf)
 	{
 		return true;
 	}
@@ -1205,7 +1195,19 @@ bool BearingCalculator::RequiredBearingEdgeToBottomFlangeEdgeDistCheck(const Bea
 	}
 }
 
-bool BearingCalculator::MaximumLiveLoadDeflectionCheck(const Bearing& brg, const BearingLoads& brg_loads, const Criteria& criteria) const
+bool BearingCalculator::MaximumLiveLoadDeflectionMethodACheck(const Bearing& brg, const BearingLoads& brg_loads, const Criteria& criteria) const
+{
+	if (GetInstantaneousLiveLoadDeflectionMethodA(brg, brg_loads) <= criteria.maxLLdef)
+	{
+		return true;
+	}
+	else
+	{
+		return false;
+	}
+}
+
+bool BearingCalculator::MaximumLiveLoadDeflectionMethodBCheck(const Bearing& brg, const BearingLoads& brg_loads, const Criteria& criteria) const
 {
 	if (GetInstantaneousLiveLoadDeflectionMethodB(brg, brg_loads) <= criteria.maxLLdef)
 	{

--- a/EngTools/BearingReporter.cpp
+++ b/EngTools/BearingReporter.cpp
@@ -391,7 +391,8 @@ void ReportBearingSpecificationCheckA(const WBFL::Units::IndirectMeasure* pDispU
 	const WBFL::EngTools::Bearing& brg,
 	const WBFL::EngTools::BearingLoads& brg_loads,
 	const WBFL::EngTools::BearingCalculator& brg_calc,
-	const WBFL::LRFD::BDSManager::Edition spec)
+	const WBFL::LRFD::BDSManager::Edition& spec,
+	const WBFL::EngTools::BearingDesignCriteria& criteria)
 
 
 {
@@ -953,7 +954,8 @@ void ReportBearingSpecificationCheckB(const WBFL::Units::IndirectMeasure* pDispU
 	const WBFL::EngTools::Bearing& brg,
 	const WBFL::EngTools::BearingLoads& brg_loads,
 	const WBFL::EngTools::BearingCalculator& brg_calc,
-	const WBFL::LRFD::BDSManager::Edition spec)
+	const WBFL::LRFD::BDSManager::Edition& spec,
+	const WBFL::EngTools::BearingDesignCriteria& criteria)
 
 {
 
@@ -1701,18 +1703,19 @@ void BearingReporter::BuildSpecCheckChapter(const WBFL::Units::IndirectMeasure* 
 	rptChapter* pChapter,
 	rptParagraph* pPara, const Bearing& brg,
 	const BearingLoads& brg_loads, const BearingCalculator& brg_calc,
-	const WBFL::LRFD::BDSManager::Edition spec)
+	const WBFL::LRFD::BDSManager::Edition& spec,
+	const WBFL::EngTools::BearingDesignCriteria& criteria)
 {
 	ReportIntroduction(pPara, brg_calc, spec);
 	ReportBearingProperties(pDispUnits, pChapter, pPara, brg, brg_loads, brg_calc);
 
 	if (brg_calc.GetAnalysisMethod() == WBFL::EngTools::BearingCalculator::AnalysisMethod::MethodA)
 	{
-		ReportBearingSpecificationCheckA(pDispUnits, pChapter, pPara, brg, brg_loads, brg_calc, spec);
+		ReportBearingSpecificationCheckA(pDispUnits, pChapter, pPara, brg, brg_loads, brg_calc, spec, criteria);
 	}
 	else
 	{
-		ReportBearingSpecificationCheckB(pDispUnits, pChapter, pPara, brg, brg_loads, brg_calc, spec);
+		ReportBearingSpecificationCheckB(pDispUnits, pChapter, pPara, brg, brg_loads, brg_calc, spec, criteria);
 	}
 }
 

--- a/EngTools/EngTools.vcxproj
+++ b/EngTools/EngTools.vcxproj
@@ -204,6 +204,7 @@
     <ClInclude Include="..\Include\EngTools\AutoLib.h" />
     <ClInclude Include="..\Include\EngTools\Bearing.h" />
     <ClInclude Include="..\Include\EngTools\BearingCalculator.h" />
+    <ClInclude Include="..\Include\EngTools\BearingDesignCriteria.h" />
     <ClInclude Include="..\Include\EngTools\BearingLoads.h" />
     <ClInclude Include="..\Include\EngTools\BearingReporter.h" />
     <ClInclude Include="..\Include\EngTools\BiaxialBeamStrain.h" />

--- a/EngTools/EngTools.vcxproj.filters
+++ b/EngTools/EngTools.vcxproj.filters
@@ -78,6 +78,9 @@
     <ClInclude Include="..\Include\EngTools\BearingReporter.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\Include\EngTools\BearingDesignCriteria.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <CustomBuild Include="EngTools.def" />

--- a/EngTools/EngToolsUnitTests/TestBearing.cpp
+++ b/EngTools/EngToolsUnitTests/TestBearing.cpp
@@ -19,8 +19,8 @@ namespace EngToolsUnitTests
 
             Assert::IsTrue(IsEqual(brg.GetLength(), WBFL::Units::ConvertToSysUnits(11.0, WBFL::Units::Measure::Inch)));
             Assert::IsTrue(IsEqual(brg.GetWidth(), WBFL::Units::ConvertToSysUnits(27.0, WBFL::Units::Measure::Inch)));
-            Assert::IsTrue(IsEqual(brg.GetShearModulusMinimum(), WBFL::Units::ConvertToSysUnits(140, WBFL::Units::Measure::PSI)));
-            Assert::IsTrue(IsEqual(brg.GetShearModulusMaximum(), WBFL::Units::ConvertToSysUnits(190, WBFL::Units::Measure::PSI)));
+            Assert::IsTrue(IsEqual(brg.GetShearModulusMinimum(), WBFL::Units::ConvertToSysUnits(165, WBFL::Units::Measure::PSI)));
+            Assert::IsTrue(IsEqual(brg.GetShearModulusMaximum(), WBFL::Units::ConvertToSysUnits(165, WBFL::Units::Measure::PSI)));
             Assert::IsTrue(IsEqual(brg.GetIntermediateLayerThickness(), WBFL::Units::ConvertToSysUnits(0.5, WBFL::Units::Measure::Inch)));
             Assert::IsTrue(IsEqual(brg.GetCoverThickness(), WBFL::Units::ConvertToSysUnits(0.25, WBFL::Units::Measure::Inch)));
             Assert::IsTrue(IsEqual(brg.GetSteelShimThickness(), WBFL::Units::ConvertToSysUnits(0.0747, WBFL::Units::Measure::Inch)));

--- a/EngTools/EngToolsUnitTests/TestBearingCalculator.cpp
+++ b/EngTools/EngToolsUnitTests/TestBearingCalculator.cpp
@@ -16,14 +16,22 @@ namespace EngToolsUnitTests
 			Bearing brg;
 			BearingLoads brg_loads;
 			BearingCalculator brg_calc;
+			BearingDesignCriteria criteria;
+
+			criteria.bHeight = true;
+			criteria.bDistBrg2gBf = true;
+			criteria.bMaxDistBrg2gBf = true;
+			criteria.bMinDistBrg2gBf = true;
+			criteria.bHri = true;
+			criteria.bMaxTL = true;
 
 			brg_calc.SetElastomerBulkModulus(WBFL::Units::ConvertToSysUnits(450, WBFL::Units::Measure::KSI));
 			brg_calc.SetMaximumAllowableStress(WBFL::Units::ConvertToSysUnits(1.25, WBFL::Units::Measure::KSI));
-			brg.SetShearModulusMinimum(WBFL::Units::ConvertToSysUnits(200, WBFL::Units::Measure::PSI));
-			brg.SetShearModulusMaximum(WBFL::Units::ConvertToSysUnits(220, WBFL::Units::Measure::PSI));
+			brg.SetShearModulusMinimum(WBFL::Units::ConvertToSysUnits(165, WBFL::Units::Measure::PSI));
+			brg.SetShearModulusMaximum(WBFL::Units::ConvertToSysUnits(165, WBFL::Units::Measure::PSI));
 			brg.SetYieldStrength(WBFL::Units::ConvertToSysUnits(36, WBFL::Units::Measure::KSI));
 			brg.SetFatigueThreshold(WBFL::Units::ConvertToSysUnits(24, WBFL::Units::Measure::KSI));
-			brg.SetCoverThickness(WBFL::Units::ConvertToSysUnits(0.35, WBFL::Units::Measure::Inch));
+			brg.SetCoverThickness(WBFL::Units::ConvertToSysUnits(0.25, WBFL::Units::Measure::Inch));
 			brg.SetLength(WBFL::Units::ConvertToSysUnits(11, WBFL::Units::Measure::Inch));
 			brg.SetWidth(WBFL::Units::ConvertToSysUnits(13, WBFL::Units::Measure::Inch));
 			brg.SetIntermediateLayerThickness(WBFL::Units::ConvertToSysUnits(0.5, WBFL::Units::Measure::Inch));
@@ -38,6 +46,8 @@ namespace EngToolsUnitTests
 			brg_loads.SetLiveLoad(WBFL::Units::ConvertToSysUnits(10, WBFL::Units::Measure::Kip));
 			brg_loads.SetFixedTranslationX(true);
 			brg_loads.SetFixedTranslationY(true);
+
+			Float64 gdrFlgDist = WBFL::Units::ConvertToSysUnits(1.0, WBFL::Units::Measure::Inch);
 
 			Assert::IsTrue(brg_calc.MinimumAreaCheck(brg, brg_loads));
 			Assert::IsTrue(brg_calc.MinimumLengthCheck(brg, brg_loads));
@@ -61,13 +71,20 @@ namespace EngToolsUnitTests
 			Assert::IsTrue(brg_calc.StaticAxialSecondaryShearStrainCheck(brg, brg_loads));
 			Assert::IsTrue(brg_calc.PrimaryShearStrainComboSumCheck(brg, brg_loads));
 			Assert::IsTrue(brg_calc.SecondaryShearStrainComboSumCheck(brg, brg_loads));
-			Assert::IsTrue(brg_calc.CheckApplicabilityTotalStressStabilityX(brg, brg_loads));
+			Assert::IsFalse(brg_calc.CheckApplicabilityTotalStressStabilityX(brg, brg_loads));
 			Assert::IsFalse(brg_calc.CheckApplicabilityTotalStressStabilityY(brg, brg_loads));
-			Assert::IsTrue(brg_calc.StabilityXDirectionCheck(brg, brg_loads));
 			Assert::IsTrue(brg_calc.RestraintSystemRequirementCheck(brg, brg_loads));
 			Assert::IsFalse(brg_calc.HydrostaticStressCheck(brg, brg_loads));
 			Assert::IsTrue(brg_calc.HorizontalForceCheck(brg, brg_loads));
-
+			Assert::IsTrue(brg_calc.MaximumLiveLoadDeflectionMethodBCheck(brg, brg_loads, criteria));
+			Assert::IsTrue(brg_calc.MinimumAllowableShearModulusCheck(brg, criteria));
+			Assert::IsTrue(brg_calc.MaximumAllowableShearModulusCheck(brg, criteria));
+			Assert::IsTrue(brg_calc.RequiredIntermediateElastomerThicknessCheck(brg, criteria));
+			Assert::IsTrue(brg_calc.MinimumTotalBearingHeightCheck(brg, criteria));
+			Assert::IsTrue(brg_calc.MinimumBearingEdgeToBottomFlangeEdgeDistCheck(brg, criteria, gdrFlgDist));
+			Assert::IsTrue(brg_calc.MaximumBearingEdgeToBottomFlangeEdgeDistCheck(brg, criteria, gdrFlgDist));
+			Assert::IsTrue(brg_calc.RequiredBearingEdgeToBottomFlangeEdgeDistCheck(brg, criteria, gdrFlgDist));
+			Assert::IsTrue(brg_calc.MaximumTotalLoadCheck(brg_loads, criteria));
 		}
 
 		TEST_METHOD(TestAllFail)
@@ -77,10 +94,19 @@ namespace EngToolsUnitTests
 			Bearing brg;
 			BearingLoads brg_loads;
 			BearingCalculator brg_calc;
+			BearingDesignCriteria criteria;
+
+			criteria.bHeight = true;
+			criteria.bDistBrg2gBf = true;
+			criteria.bMaxDistBrg2gBf = true;
+			criteria.bMinDistBrg2gBf = true;
+			criteria.bHri = true;
+			criteria.bMaxTL = true;
+
 
 			brg_calc.SetElastomerBulkModulus(WBFL::Units::ConvertToSysUnits(450, WBFL::Units::Measure::KSI));
 			brg_calc.SetMaximumAllowableStress(WBFL::Units::ConvertToSysUnits(1.25, WBFL::Units::Measure::KSI));
-			brg.SetShearModulusMinimum(WBFL::Units::ConvertToSysUnits(200, WBFL::Units::Measure::PSI));
+			brg.SetShearModulusMinimum(WBFL::Units::ConvertToSysUnits(70, WBFL::Units::Measure::PSI));
 			brg.SetShearModulusMaximum(WBFL::Units::ConvertToSysUnits(220, WBFL::Units::Measure::PSI));
 			brg.SetYieldStrength(WBFL::Units::ConvertToSysUnits(2, WBFL::Units::Measure::KSI));
 			brg.SetFatigueThreshold(WBFL::Units::ConvertToSysUnits(2, WBFL::Units::Measure::KSI));
@@ -88,18 +114,19 @@ namespace EngToolsUnitTests
 			brg.SetLength(WBFL::Units::ConvertToSysUnits(6, WBFL::Units::Measure::Inch));
 			brg.SetWidth(WBFL::Units::ConvertToSysUnits(6, WBFL::Units::Measure::Inch));
 			brg.SetIntermediateLayerThickness(WBFL::Units::ConvertToSysUnits(0.25, WBFL::Units::Measure::Inch));
-			brg.SetNumIntLayers(6);
+			brg.SetNumIntLayers(1);
 			brg.SetSteelShimThickness(WBFL::Units::ConvertToSysUnits(0.0005, WBFL::Units::Measure::Inch));
 			brg_loads.SetStaticRotation(0.0001);
 			brg_loads.SetCyclicRotation(0.0001);
 			brg_loads.SetRotationX(0.000);
 			brg_loads.SetRotationY(0.000);
 			brg_loads.SetShearDeformation(WBFL::Units::ConvertToSysUnits(0.8, WBFL::Units::Measure::Inch));
-			brg_loads.SetDeadLoad(WBFL::Units::ConvertToSysUnits(200, WBFL::Units::Measure::Kip));
+			brg_loads.SetDeadLoad(WBFL::Units::ConvertToSysUnits(2000, WBFL::Units::Measure::Kip));
 			brg_loads.SetLiveLoad(WBFL::Units::ConvertToSysUnits(100, WBFL::Units::Measure::Kip));
 			brg_loads.SetFixedTranslationX(false);
 			brg_loads.SetFixedTranslationY(false);
 
+			Float64 gdrFlgDist = WBFL::Units::ConvertToSysUnits(10.0, WBFL::Units::Measure::Inch);
 
 			Assert::IsFalse(brg_calc.MinimumAreaCheck(brg, brg_loads));
 			Assert::IsFalse(brg_calc.MinimumLengthCheck(brg, brg_loads));
@@ -107,7 +134,7 @@ namespace EngToolsUnitTests
 			Assert::IsFalse(brg_calc.MaximumStressCheck(brg, brg_loads));
 			Assert::IsFalse(brg_calc.MaximumIntermediateLayerThicknessCheck(brg, brg_loads));
 			Assert::IsFalse(brg_calc.MinimumShapeFactorCheck(brg, brg_loads));
-			Assert::IsTrue(brg_calc.MaximumShapeFactorCheck(brg, brg_loads));
+			Assert::IsFalse(brg_calc.MaximumShapeFactorCheck(brg, brg_loads));
 			Assert::IsFalse(brg_calc.MinimumNumLayersShearDeformationCheck(brg, brg_loads));
 			Assert::IsTrue(brg_calc.MinimumNumLayersRotationXCheck(brg, brg_loads));
 			Assert::IsTrue(brg_calc.MinimumNumLayersRotationYCheck(brg, brg_loads));
@@ -124,13 +151,20 @@ namespace EngToolsUnitTests
 			Assert::IsFalse(brg_calc.StaticAxialSecondaryShearStrainCheck(brg, brg_loads));
 			Assert::IsFalse(brg_calc.PrimaryShearStrainComboSumCheck(brg, brg_loads));
 			Assert::IsFalse(brg_calc.SecondaryShearStrainComboSumCheck(brg, brg_loads));
-			Assert::IsTrue(brg_calc.CheckApplicabilityTotalStressStabilityX(brg, brg_loads));
-			Assert::IsTrue(brg_calc.CheckApplicabilityTotalStressStabilityY(brg, brg_loads));
-			Assert::IsFalse(brg_calc.StabilityXDirectionCheck(brg, brg_loads));
-			Assert::IsFalse(brg_calc.StabilityYDirectionCheck(brg, brg_loads));
+			Assert::IsFalse(brg_calc.CheckApplicabilityTotalStressStabilityX(brg, brg_loads));
+			Assert::IsFalse(brg_calc.CheckApplicabilityTotalStressStabilityY(brg, brg_loads));
 			Assert::IsTrue(brg_calc.RestraintSystemRequirementCheck(brg, brg_loads));
 			Assert::IsFalse(brg_calc.HydrostaticStressCheck(brg, brg_loads));
 			Assert::IsTrue(brg_calc.HorizontalForceCheck(brg, brg_loads));
+			Assert::IsTrue(brg_calc.MaximumLiveLoadDeflectionMethodBCheck(brg, brg_loads, criteria));
+			Assert::IsFalse(brg_calc.MinimumAllowableShearModulusCheck(brg, criteria));
+			Assert::IsFalse(brg_calc.MaximumAllowableShearModulusCheck(brg, criteria));
+			Assert::IsFalse(brg_calc.RequiredIntermediateElastomerThicknessCheck(brg, criteria));
+			Assert::IsFalse(brg_calc.MinimumTotalBearingHeightCheck(brg, criteria));
+			Assert::IsTrue(brg_calc.MinimumBearingEdgeToBottomFlangeEdgeDistCheck(brg, criteria, gdrFlgDist));
+			Assert::IsFalse(brg_calc.MaximumBearingEdgeToBottomFlangeEdgeDistCheck(brg, criteria, gdrFlgDist));
+			Assert::IsFalse(brg_calc.RequiredBearingEdgeToBottomFlangeEdgeDistCheck(brg, criteria, gdrFlgDist));
+			Assert::IsFalse(brg_calc.MaximumTotalLoadCheck(brg_loads, criteria));
 		}
 
 
@@ -292,6 +326,8 @@ namespace EngToolsUnitTests
 			Assert::IsFalse(brg_calc.MinimumNumLayersRotationYCheck(brg, brg_loads));
 
 		};
+
+		//TO DO: add stability failure when applicable
 
         
     };

--- a/EngTools/EngToolsUnitTests/TestBearingLoads.cpp
+++ b/EngTools/EngToolsUnitTests/TestBearingLoads.cpp
@@ -13,9 +13,6 @@ namespace EngToolsUnitTests
 
 		TEST_METHOD(Test)
 		{
-
-
-
 			BearingLoads brg_loads;
 
 			Assert::IsTrue(IsEqual(brg_loads.GetDeadLoad(), WBFL::Units::ConvertToSysUnits(86.0, WBFL::Units::Measure::Kip)));
@@ -28,10 +25,6 @@ namespace EngToolsUnitTests
 			Assert::IsTrue(IsEqual(brg_loads.GetShearDeformation(), WBFL::Units::ConvertToSysUnits(0.47, WBFL::Units::Measure::Inch)));
 			Assert::IsTrue(IsEqual(brg_loads.GetEffectiveKFactorX(), 1.0));
 			Assert::IsTrue(IsEqual(brg_loads.GetEffectiveKFactorY(), 2.0));
-
-
-
-
 
 		}
 	};

--- a/Include/EngTools/Bearing.h
+++ b/Include/EngTools/Bearing.h
@@ -130,8 +130,8 @@ namespace WBFL
         private:
             Float64 m_length{ WBFL::Units::ConvertToSysUnits(11, WBFL::Units::Measure::Inch) }; ///< length
             Float64 m_width{ WBFL::Units::ConvertToSysUnits(27, WBFL::Units::Measure::Inch) };///< width
-            Float64 m_shear_modulus_min{ WBFL::Units::ConvertToSysUnits(140, WBFL::Units::Measure::PSI) };///< minimum shear modulus
-            Float64 m_shear_modulus_max{ WBFL::Units::ConvertToSysUnits(190, WBFL::Units::Measure::PSI) };///< maximum shear modulus
+            Float64 m_shear_modulus_min{ WBFL::Units::ConvertToSysUnits(165, WBFL::Units::Measure::PSI) };///< minimum shear modulus
+            Float64 m_shear_modulus_max{ WBFL::Units::ConvertToSysUnits(165, WBFL::Units::Measure::PSI) };///< maximum shear modulus
             Float64 m_intermediate_layer_thickness{ WBFL::Units::ConvertToSysUnits(0.5, WBFL::Units::Measure::Inch) };///< intermediate elastomer layer thickness
             Float64 m_cover_thickness{ WBFL::Units::ConvertToSysUnits(0.25, WBFL::Units::Measure::Inch) };///< steel cover thickness
             Float64 m_steel_shim_thickness{ WBFL::Units::ConvertToSysUnits(0.0747, WBFL::Units::Measure::Inch) };///< steel shim thickness

--- a/Include/EngTools/BearingCalculator.h
+++ b/Include/EngTools/BearingCalculator.h
@@ -292,7 +292,7 @@ namespace WBFL
             bool HydrostaticStressCheck(const Bearing&, const BearingLoads&) const;
             /// @return Check for the minmimum allowable shear modulus
             bool MinimumAllowableShearModulusCheck(const Bearing&, const Criteria&) const;
-            /// @return Check for the maximum allowable shear modulus
+            /// @return Check for the maximum allowable shear modulus (method A)
             bool MaximumAllowableShearModulusCheck(const Bearing&, const Criteria&) const;
             /// @return Required intermediate elastomer layer thickness check
             bool RequiredIntermediateElastomerThicknessCheck(const Bearing&, const Criteria&) const;
@@ -304,8 +304,10 @@ namespace WBFL
             bool MaximumBearingEdgeToBottomFlangeEdgeDistCheck(const Bearing&, const Criteria&, Float64) const;
             /// @return Required bearing edge to girder bottom flange distance Check
             bool RequiredBearingEdgeToBottomFlangeEdgeDistCheck(const Bearing&, const Criteria&, Float64) const;
-            /// @return Maximum live load deflection check
-            bool MaximumLiveLoadDeflectionCheck(const Bearing&, const BearingLoads&, const Criteria&) const;
+            /// @return Maximum live load deflection (method A) check
+            bool MaximumLiveLoadDeflectionMethodACheck(const Bearing&, const BearingLoads&, const Criteria&) const;
+            /// @return Maximum live load deflection (method B) check
+            bool MaximumLiveLoadDeflectionMethodBCheck(const Bearing&, const BearingLoads&, const Criteria&) const;
             /// @return Maximum total vertical service load check
             bool MaximumTotalLoadCheck(const BearingLoads&, const Criteria&) const;
             

--- a/Include/EngTools/BearingCalculator.h
+++ b/Include/EngTools/BearingCalculator.h
@@ -25,6 +25,7 @@
 #include <EngTools\EngToolsExp.h>
 #include <EngTools\Bearing.h>
 #include <EngTools\BearingLoads.h>
+#include <EngTools\BearingDesignCriteria.h>
 #include <LRFD/BDSManager.h>
 
 
@@ -45,6 +46,7 @@ namespace WBFL
 
         public:
             typedef WBFL::LRFD::BDSManager::Edition SpecType;
+            typedef WBFL::EngTools::BearingDesignCriteria Criteria;
 
             BearingCalculator() = default;
             BearingCalculator(SpecType spec)
@@ -69,6 +71,8 @@ namespace WBFL
             void SetSpecification(SpecType spec);
             /// @brief Set Analysis Method
             void SetAnalysisMethod(AnalysisMethod method);
+            /// @brief Set Design Criteria
+            void SetDesignCriteria(const Criteria& criteria);
             /// @brief Set Maximum Alowable Bearing Stress
             /// @param sigma_max
             void SetMaximumAllowableStress(Float64 sigma_max);
@@ -76,7 +80,7 @@ namespace WBFL
             /// @param k
             void SetElastomerBulkModulus(Float64 k);
 
-            /// @return computes total bearing height
+            /// @return compute total bearing height
             Float64 ComputeBearingHeight(const Bearing& brg) const;
 
             /// @return analysis method
@@ -225,6 +229,8 @@ namespace WBFL
             Float64 RestraintSystemCalc(const Bearing&, const BearingLoads&) const;
             /// @return horizontal force
             Float64 GetHorizontalForce(const Bearing&, const BearingLoads&) const;
+            /// @return Minimum Allowable Shear Modulus
+
 
             /// @return Check for the minimum required bearing pad area
             bool MinimumAreaCheck(const Bearing&, const BearingLoads&) const;
@@ -284,13 +290,36 @@ namespace WBFL
             bool HorizontalForceCheck(const Bearing&, const BearingLoads&) const;
             /// @return Check for the maximum allowable hydrostatic stress
             bool HydrostaticStressCheck(const Bearing&, const BearingLoads&) const;
+            /// @return Check for the minmimum allowable shear modulus
+            bool MinimumAllowableShearModulusCheck(const Bearing&, const Criteria&) const;
+            /// @return Check for the maximum allowable shear modulus
+            bool MaximumAllowableShearModulusCheck(const Bearing&, const Criteria&) const;
+            /// @return Required intermediate elastomer layer thickness check
+            bool RequiredIntermediateElastomerThicknessCheck(const Bearing&, const Criteria&) const;
+            /// @return Minimum Total Bearing Height Check
+            bool MinimumTotalBearingHeightCheck(const Bearing&, const Criteria&) const;
+            /// @return Minimum bearing edge to girder bottom flange distance Check
+            bool MinimumBearingEdgeToBottomFlangeEdgeDistCheck(const Bearing&, const Criteria&, Float64) const;
+            /// @return Maximum bearing edge to girder bottom flange distance Check
+            bool MaximumBearingEdgeToBottomFlangeEdgeDistCheck(const Bearing&, const Criteria&, Float64) const;
+            /// @return Required bearing edge to girder bottom flange distance Check
+            bool RequiredBearingEdgeToBottomFlangeEdgeDistCheck(const Bearing&, const Criteria&, Float64) const;
+            /// @return Maximum live load deflection check
+            bool MaximumLiveLoadDeflectionCheck(const Bearing&, const BearingLoads&, const Criteria&) const;
+            /// @return Maximum total vertical service load check
+            bool MaximumTotalLoadCheck(const BearingLoads&, const Criteria&) const;
+            
+
+
 
         private:
-           AnalysisMethod m_method{AnalysisMethod::MethodA};
+           AnalysisMethod m_method{AnalysisMethod::MethodA};///< design method
            Float64 m_maximum_allowable_stress{ WBFL::Units::ConvertToSysUnits(1.25, WBFL::Units::Measure::KSI) };///< max allowable stress
            Float64 m_elastomer_bulk_modulus{ WBFL::Units::ConvertToSysUnits(450, WBFL::Units::Measure::KSI) };///< elastomer bulk modulus
            SpecType m_specification{WBFL::LRFD::BDSManager::Edition::LastEdition};///< AASHTO BDS spec
+           Criteria m_criteria;///< Bearing design criteria
            Float64 m_Ecoeff{ 4.8 };///< coefficient used in elastic modulus calculation
+           Float64 m_girder_edge_dist{ 10.0 };///< girder edge distance from bearing center line
         };
     }; // EngTools
 }; // WBFL

--- a/Include/EngTools/BearingDesignCriteria.h
+++ b/Include/EngTools/BearingDesignCriteria.h
@@ -1,0 +1,54 @@
+///////////////////////////////////////////////////////////////////////
+// Stability
+// Copyright © 1999-2025  Washington State Department of Transportation
+//                        Bridge and Structures Office
+//
+// This library is a part of the Washington Bridge Foundation Libraries
+// and was developed as part of the Alternate Route Project
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the Alternate Route Library Open Source License as published by 
+// the Washington State Department of Transportation, Bridge and Structures Office.
+//
+// This program is distributed in the hope that it will be useful, but is distributed 
+// AS IS, WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY 
+// or FITNESS FOR A PARTICULAR PURPOSE. See the Alternate Route Library Open Source 
+// License for more details.
+//
+// You should have received a copy of the Alternate Route Library Open Source License 
+// along with this program; if not, write to the Washington State Department of 
+// Transportation, Bridge and Structures Office, P.O. Box  47340, 
+// Olympia, WA 98503, USA or e-mail Bridge_Support@wsdot.wa.gov
+///////////////////////////////////////////////////////////////////////
+
+#pragma once
+#include <EngTools\EngToolsExp.h>
+
+
+
+namespace WBFL
+{
+    namespace EngTools
+    {
+        /// Criteria for bearing analysis
+        struct BearingDesignCriteria
+        {
+
+            Float64 Gmin{ WBFL::Units::ConvertToSysUnits(0.080, WBFL::Units::Measure::KSI) }; ///< Minimum Elastomer Shear Modulus
+            Float64 Gmax{ WBFL::Units::ConvertToSysUnits(0.175, WBFL::Units::Measure::KSI) }; ///< Maximum Elastomer Shear Modulus
+            Float64 maxLLdef{ WBFL::Units::ConvertToSysUnits(0.125, WBFL::Units::Measure::Inch) }; ///< Maximum Live Load Deflection
+            bool bHri{ false }; ///< Specific intermediate layer thickness requirement
+            Float64 hri{ WBFL::Units::ConvertToSysUnits(0.5, WBFL::Units::Measure::Inch) }; ///< Required Intermediate Elastomer Layer Thickness
+            bool bHeight{ false }; ///< Minimum Total Bearing Height Requirement
+            Float64 minHeight{ WBFL::Units::ConvertToSysUnits(1.0, WBFL::Units::Measure::Inch) }; ///< Minimum Total Bearing Height
+            bool bMinDistBrg2gBf{ false }; ///< Minimum distance from edge of bearing to edge of girder bottom flange requirement
+            Float64 minDistBrg2gBf{ WBFL::Units::ConvertToSysUnits(1.0, WBFL::Units::Measure::Inch) }; ///< Minimum distance from edge of bearing to edge of girder bottom flange
+            bool bMaxDistBrg2gBf{ false }; ///< Maximum distance from edge of bearing to edge of girder bottom flange requirement
+            Float64 maxDistBrg2gBf{ WBFL::Units::ConvertToSysUnits(9.0, WBFL::Units::Measure::Inch) }; ///< Maximum distance from edge of bearing to edge of girder bottom flange
+            bool bDistBrg2gBf{ false }; ///< Distance from edge of bearing to edge of girder bottom flange requirement
+            Float64 distBrg2gBf{ WBFL::Units::ConvertToSysUnits(1.0, WBFL::Units::Measure::Inch) }; ///< Required distance from edge of bearing to edge of girder bottom flange
+            bool bMaxTL{ false };///< Maximum vertical service load requirement
+            Float64 maxTL{ WBFL::Units::ConvertToSysUnits(800.0, WBFL::Units::Measure::Kip) }; ///< Maximum vertical service load
+        };
+    }
+}

--- a/Include/EngTools/BearingReporter.h
+++ b/Include/EngTools/BearingReporter.h
@@ -25,9 +25,11 @@
 #include <EngTools\Bearing.h>
 #include <EngTools\BearingLoads.h>
 #include <EngTools\BearingCalculator.h>
+#include <EngTools\BearingDesignCriteria.h>
 #include <Reporter\Chapter.h>
 #include <Units/IndirectMeasure.h>
 #include <LRFD/BDSManager.h>
+
 
 
 namespace WBFL
@@ -43,7 +45,8 @@ namespace WBFL
          /// Builds the specification check chapter
          void BuildSpecCheckChapter(const WBFL::Units::IndirectMeasure* pDispUnits, rptChapter* pChapter, 
              rptParagraph* pPara, const Bearing& brg, const BearingLoads& brg_loads, 
-             const BearingCalculator& brg_calc, const WBFL::LRFD::BDSManager::Edition spec);
+             const BearingCalculator& brg_calc, const WBFL::LRFD::BDSManager::Edition& spec,
+             const WBFL::EngTools::BearingDesignCriteria& criteria);
       };
    }
 }

--- a/Include/EngTools/BearingReporter.h
+++ b/Include/EngTools/BearingReporter.h
@@ -46,7 +46,7 @@ namespace WBFL
          void BuildSpecCheckChapter(const WBFL::Units::IndirectMeasure* pDispUnits, rptChapter* pChapter, 
              rptParagraph* pPara, const Bearing& brg, const BearingLoads& brg_loads, 
              const BearingCalculator& brg_calc, const WBFL::LRFD::BDSManager::Edition& spec,
-             const WBFL::EngTools::BearingDesignCriteria& criteria);
+             const WBFL::EngTools::BearingDesignCriteria& criteria, Float64 gdrFlgDist = 0.0);
       };
    }
 }


### PR DESCRIPTION
BearingDesignCriteria object added to WBFL. Includes BDM criteria. Criteria for minimum and maximum shear modulus added to BrgCalc report (other criteria is turned off).

Additional unit tests were added for the additional criteria.

I decided to deal with the bottom flange edge distance requirement by adding a Float64 parameter to BuildSpecCheckChapter(). This allows for granular control of organizing the report, and handle overall pass/fail of entire bearing design in WBFL, rather than have separate pass/fails in the report (i.e. pass/fail AASHTO and pass/fail BDM).